### PR TITLE
feat: display creator meta in navbar

### DIFF
--- a/web/app/attendance/page.tsx
+++ b/web/app/attendance/page.tsx
@@ -2,7 +2,7 @@
 // Where to edit: 근태 출근/퇴근 동작을 수정하려면 loadAttendance, handlePunchIn/Out 함수를 확인하세요.
 /**
  * @file web/app/attendance/page.tsx
- * @description PocketBase 근태 기록을 조회하고 출근/퇴근을 기록하는 페이지입니다.
+ * @description PocketBase 근태 기록을 최신 스레드형 카드 UI로 조회하고 출근/퇴근을 기록하는 페이지이다.
  */
 
 import React from 'react';
@@ -145,54 +145,80 @@ export default function AttendancePage() {
   };
 
   if (!isAuthenticated) {
-    return <p className="text-sm">로그인 후 근태를 기록할 수 있습니다.</p>;
+    return (
+      <section className="thread-section">
+        <article className="thread-panel thread-panel--muted">
+          <p className="thread-muted">로그인 후 근태를 기록할 수 있습니다.</p>
+        </article>
+      </section>
+    );
   }
 
   const hasCheckedIn = Boolean(record?.check_in_at);
   const hasCheckedOut = Boolean(record?.check_out_at);
 
   return (
-    <section className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-bold">근태 기록</h1>
-        <p className="text-sm text-slate-600">PocketBase의 attendance 컬렉션과 연동됩니다.</p>
+    <section className="thread-section">
+      <header className="thread-section__header">
+        <span className="thread-eyebrow">Attendance Thread</span>
+        <h1 className="thread-title">근태 기록</h1>
+        <p className="thread-subtitle">PocketBase의 attendance 컬렉션과 연동되어 역할에 맞춘 기록 흐름을 제공합니다.</p>
       </header>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="table-like space-y-3">
-          <h2 className="text-lg font-semibold">오늘의 기록</h2>
-          <p className="text-sm">출근 시간: {formatDate(record?.check_in_at)}</p>
-          <p className="text-sm">퇴근 시간: {formatDate(record?.check_out_at)}</p>
-          <p className="text-xs text-slate-500">참고 메모: {record?.note ?? '-'}</p>
-        </div>
+      <div className="thread-grid thread-grid--two">
+        {/* 오늘의 기록을 타임라인 카드로 보여준다. */}
+        <article className="thread-panel">
+          <div className="thread-meta">
+            <span>출근 · {formatDate(record?.check_in_at)}</span>
+            <span>퇴근 · {formatDate(record?.check_out_at)}</span>
+          </div>
+          <h2>오늘의 기록</h2>
+          <p className="thread-panel__description">현재 날짜 기준으로 가장 최신 근태 정보를 불러옵니다.</p>
+          <div className="thread-card-divider" />
+          <div className="thread-meta">
+            <span className={`thread-pill${hasCheckedIn ? ' thread-pill--accent' : ''}`}>
+              {hasCheckedIn ? '출근 완료' : '출근 대기'}
+            </span>
+            <span className={`thread-pill${hasCheckedOut ? ' thread-pill--accent' : ''}`}>
+              {hasCheckedOut ? '퇴근 완료' : '퇴근 대기'}
+            </span>
+          </div>
+          <p className="thread-muted">참고 메모 · {record?.note ?? '-'}</p>
+        </article>
 
-        <div className="table-like space-y-4">
+        {/* 출근/퇴근 액션 영역을 구성한다. */}
+        <article className="thread-panel">
+          <h2>액션</h2>
+          <p className="thread-panel__description">근태 버튼을 눌러 스레드에 새로운 이벤트를 추가하세요.</p>
+          <div className="thread-card-divider" />
           <button
-            className="w-full rounded bg-emerald-600 py-2 text-white disabled:opacity-40"
+            className="thread-button thread-button--primary"
             onClick={handlePunchIn}
             disabled={isLoading || hasCheckedIn}
           >
-            {hasCheckedIn ? '출근 완료' : '출근하기'}
+            {hasCheckedIn ? '출근 완료' : '출근 기록하기'}
           </button>
           <button
-            className="w-full rounded bg-rose-600 py-2 text-white disabled:opacity-40"
+            className="thread-button thread-button--danger"
             onClick={() => setShowConfirm(true)}
             disabled={isLoading || !hasCheckedIn || hasCheckedOut}
           >
-            {hasCheckedOut ? '퇴근 완료' : '퇴근하기'}
+            {hasCheckedOut ? '퇴근 완료' : '퇴근 요청하기'}
           </button>
-        </div>
+          <p className="thread-muted">퇴근은 한 번 기록하면 수정이 어려우니 주의하세요.</p>
+        </article>
       </div>
 
       {showConfirm ? (
-        <div className="fixed inset-0 flex items-center justify-center bg-slate-900/60">
-          <div className="w-full max-w-sm space-y-4 rounded-lg bg-white p-6 shadow-xl">
-            <p className="text-sm">퇴근을 기록하면 수정이 어려울 수 있습니다. 계속 진행할까요?</p>
-            <div className="flex gap-2 text-sm">
-              <button className="flex-1 rounded border px-3 py-2" onClick={() => setShowConfirm(false)}>
+        <div className="thread-modal" role="dialog" aria-modal="true">
+          <div className="thread-modal__card">
+            <h2>퇴근을 기록할까요?</h2>
+            <p className="thread-muted">퇴근을 확정하면 편집 잠금이 적용될 수 있습니다. 계속 진행할지 선택하세요.</p>
+            <div className="thread-modal__actions">
+              <button className="thread-button thread-button--ghost" onClick={() => setShowConfirm(false)}>
                 취소
               </button>
-              <button className="flex-1 rounded bg-rose-600 px-3 py-2 text-white" onClick={handlePunchOut}>
+              <button className="thread-button thread-button--danger" onClick={handlePunchOut}>
                 퇴근 확정
               </button>
             </div>
@@ -200,8 +226,8 @@ export default function AttendancePage() {
         </div>
       ) : null}
 
-      {info ? <p className="text-sm text-green-600">{info}</p> : null}
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {info ? <div className="thread-alert thread-alert--success">{info}</div> : null}
+      {error ? <div className="thread-alert thread-alert--error">{error}</div> : null}
     </section>
   );
 }

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 // Where to edit: 대시보드 카드 구성이나 권한별 UI를 변경하려면 SUMMARY_TILES와 fetchSummaries를 업데이트하세요.
 /**
  * @file web/app/dashboard/page.tsx
- * @description 역할 기반 대시보드와 공유 제어 UI를 제공하는 페이지입니다.
+ * @description 역할 기반 대시보드를 최신 스레드형 카드 스타일로 구성해 주요 통계를 보여주는 페이지이다.
  */
 
 import React from 'react';
@@ -92,34 +92,41 @@ export default function DashboardPage() {
   };
 
   if (!isAuthenticated) {
-    return <p className="text-sm">로그인 후 대시보드를 확인할 수 있습니다.</p>;
+    return (
+      <section className="thread-section">
+        <article className="thread-panel thread-panel--muted">
+          <p className="thread-muted">로그인 후 대시보드를 확인할 수 있습니다.</p>
+        </article>
+      </section>
+    );
   }
 
   return (
-    <section className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-bold">대시보드</h1>
-        <p className="text-sm text-slate-600">역할({role})에 따라 노출되는 정보가 다릅니다.</p>
+    <section className="thread-section">
+      <header className="thread-section__header">
+        <span className="thread-eyebrow">Team Overview Thread</span>
+        <h1 className="thread-title">대시보드</h1>
+        <p className="thread-subtitle">역할({role})에 따라 노출되는 정보가 달라집니다. 팀의 흐름을 한눈에 확인하세요.</p>
       </header>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="thread-grid thread-grid--four">
         {tiles.map((tile) => (
-          <article key={tile.id} className="table-like space-y-2">
-            <h2 className="text-lg font-semibold">{tile.label}</h2>
-            <p className="text-xs text-slate-500">{tile.description}</p>
-            <p className="text-3xl font-bold">{tile.count}</p>
+          <article key={tile.id} className="thread-panel thread-panel--stat">
+            <h2>{tile.label}</h2>
+            <p className="thread-panel__metric">{tile.count}</p>
+            <p className="thread-panel__description">{tile.description}</p>
           </article>
         ))}
       </div>
 
-      <section className="table-like space-y-3">
-        <header className="flex items-center justify-between">
+      <article className="thread-panel thread-panel--muted">
+        <header className="thread-meta">
           <div>
-            <h2 className="text-base font-semibold">공유 설정</h2>
-            <p className="text-xs text-slate-500">주간 보고서를 지정된 Obsidian 폴더에 복사하도록 설정합니다.</p>
+            <h2>공유 설정</h2>
+            <p className="thread-muted">주간 보고서를 지정된 Obsidian 폴더에 복사하도록 설정합니다.</p>
           </div>
           <button
-            className="rounded bg-indigo-600 px-4 py-2 text-sm text-white disabled:opacity-40"
+            className="thread-button thread-button--primary"
             onClick={handleSharingToggle}
             disabled={role !== 'admin'}
           >
@@ -127,12 +134,12 @@ export default function DashboardPage() {
           </button>
         </header>
         {role !== 'admin' ? (
-          <p className="text-xs text-amber-600">관리자만 공유 설정을 바꿀 수 있습니다.</p>
+          <div className="thread-alert thread-alert--info">관리자만 공유 설정을 바꿀 수 있습니다.</div>
         ) : null}
-      </section>
+      </article>
 
-      {info ? <p className="text-sm text-green-600">{info}</p> : null}
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {info ? <div className="thread-alert thread-alert--success">{info}</div> : null}
+      {error ? <div className="thread-alert thread-alert--error">{error}</div> : null}
     </section>
   );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,11 +1,58 @@
 /*
  * @file web/app/globals.css
- * @description 간단한 전역 스타일 정의. Tailwind 없이 기본 유틸리티 클래스를 사용한다.
+ * @description 전역 타이포그래피와 최신 스레드형 UI 감성을 위한 유틸리티 클래스를 정의한다.
  */
 
 :root {
   color-scheme: light;
   font-family: 'Pretendard', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --app-gradient-start: #0f172a;
+  --app-gradient-end: #1e1b4b;
+  --surface-primary: rgba(15, 23, 42, 0.82);
+  --surface-secondary: rgba(30, 41, 59, 0.82);
+  --surface-border: rgba(148, 163, 184, 0.32);
+  --surface-highlight: linear-gradient(135deg, rgba(59, 130, 246, 0.28), rgba(99, 102, 241, 0.24));
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(226, 232, 240, 0.92);
+  --text-muted: rgba(148, 163, 184, 0.9);
+  --accent: #60a5fa;
+  --accent-strong: #3b82f6;
+  --danger: #f87171;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --content-max-width: 1120px;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 24px 48px rgba(15, 23, 42, 0.35);
+  --shadow-small: 0 12px 30px rgba(15, 23, 42, 0.25);
+  --shadow-inner: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  --transition: 180ms ease-in-out;
+  --spacing-xl: 3rem;
+  --spacing-lg: 2rem;
+  --spacing-md: 1.25rem;
+  --spacing-sm: 0.75rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background: radial-gradient(circle at 0% 0%, rgba(59, 130, 246, 0.4), transparent 46%),
+    radial-gradient(circle at 100% 0%, rgba(236, 72, 153, 0.38), transparent 52%),
+    linear-gradient(160deg, var(--app-gradient-start), var(--app-gradient-end));
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 a {
@@ -13,14 +60,601 @@ a {
   text-decoration: none;
 }
 
-button {
-  cursor: pointer;
+a:hover {
+  text-decoration: none;
 }
 
-.table-like {
-  border: 1px solid #cbd5f5;
-  border-radius: 0.75rem;
+button {
+  cursor: pointer;
+  font-family: inherit;
+}
+
+p,
+ul,
+ol {
+  margin: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-weight: 700;
+  color: inherit;
+}
+
+.app-background {
+  min-height: 100vh;
+  position: relative;
+}
+
+.app-shell {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--spacing-xl) 1.5rem 4rem;
+}
+
+.app-shell::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.35), transparent 55%),
+    linear-gradient(310deg, rgba(236, 72, 153, 0.25), transparent 60%);
+  opacity: 0.75;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-container {
+  width: min(var(--content-max-width), 100%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  position: relative;
+  z-index: 1;
+}
+
+.thread-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.72));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-small);
+  backdrop-filter: blur(22px);
+  gap: 1rem;
+}
+
+.thread-navbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.thread-navbar__brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(14, 165, 233, 0.85));
+  box-shadow: 0 14px 30px rgba(14, 165, 233, 0.35);
+  color: #fff;
+  font-weight: 800;
+}
+
+.thread-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.thread-nav-link {
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  border: 1px solid transparent;
+  transition: background var(--transition), color var(--transition), transform var(--transition), border var(--transition);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.thread-nav-link:hover {
+  background: rgba(99, 102, 241, 0.28);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.thread-nav-link--primary {
+  background: rgba(59, 130, 246, 0.32);
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #fff;
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.3);
+}
+
+.thread-navbar__meta {
+  /* 우측 상단 메타 영역을 세로 정렬해 제작자와 버전 정보를 명확히 노출한다. */
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: calc(var(--spacing-sm) / 2);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.thread-navbar__meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing-sm) / 4);
+  align-items: flex-end;
+}
+
+.thread-navbar__meta-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.thread-navbar__meta-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.thread-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.thread-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.thread-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.thread-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.thread-title {
+  font-size: clamp(2rem, 4vw, 2.7rem);
+  line-height: 1.2;
+}
+
+.thread-subtitle {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  max-width: 640px;
+  line-height: 1.65;
+}
+
+.thread-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.88), rgba(30, 41, 59, 0.78));
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-small);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+}
+
+.thread-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--surface-highlight);
+  opacity: 0;
+  transition: opacity var(--transition);
+  pointer-events: none;
+}
+
+.thread-panel:hover::before {
+  opacity: 0.75;
+}
+
+.thread-panel--accent {
+  background: linear-gradient(150deg, rgba(59, 130, 246, 0.28), rgba(15, 23, 42, 0.88));
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.thread-panel--muted {
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.78));
+}
+
+.thread-panel--stat {
+  gap: 0.4rem;
+}
+
+.thread-panel__metric {
+  font-size: 2.7rem;
+  font-weight: 700;
+}
+
+.thread-panel__description {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.thread-grid {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.thread-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.thread-grid--four {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.thread-grid--kanban {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
+}
+
+.thread-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.thread-pill--accent {
+  background: rgba(96, 165, 250, 0.25);
+  border-color: rgba(96, 165, 250, 0.4);
+  color: #fff;
+}
+
+.thread-button {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1.1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-secondary);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition), border var(--transition);
+}
+
+.thread-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.32);
+}
+
+.thread-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.thread-button--primary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.92), rgba(59, 130, 246, 0.88));
+  border-color: rgba(96, 165, 250, 0.55);
+  color: #fff;
+}
+
+.thread-button--danger {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.92), rgba(239, 68, 68, 0.88));
+  border-color: rgba(248, 113, 113, 0.55);
+  color: #fff;
+}
+
+.thread-button--ghost {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+.thread-button--link {
+  background: transparent;
+  border-color: transparent;
+  padding-inline: 0;
+  justify-content: flex-start;
+}
+
+.thread-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.thread-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.thread-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.thread-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: #fff;
+  transition: border var(--transition), box-shadow var(--transition);
+}
+
+.thread-input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.55);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.thread-alert {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+}
+
+.thread-alert--success {
+  background: rgba(52, 211, 153, 0.18);
+  border-color: rgba(52, 211, 153, 0.45);
+  color: #bbf7d0;
+}
+
+.thread-alert--error {
+  background: rgba(248, 113, 113, 0.2);
+  border-color: rgba(248, 113, 113, 0.45);
+  color: #fecaca;
+}
+
+.thread-alert--info {
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.4);
+  color: #dbeafe;
+}
+
+.thread-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.2rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.thread-timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  position: relative;
+}
+
+.thread-timeline::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  bottom: 6px;
+  left: 18px;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.55), rgba(96, 165, 250, 0));
+}
+
+.thread-timeline__item {
+  display: flex;
+  gap: 1.25rem;
+  position: relative;
+}
+
+.thread-timeline__badge {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(14, 165, 233, 0.88));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #fff;
+  box-shadow: 0 14px 26px rgba(14, 165, 233, 0.35);
+  flex-shrink: 0;
+}
+
+.thread-timeline__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--text-secondary);
+}
+
+.thread-timeline__title {
+  font-size: 1.05rem;
+}
+
+.thread-timeline__hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.thread-kanban-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.thread-kanban-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   padding: 1rem;
-  background: white;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  box-shadow: var(--shadow-inner);
+}
+
+.thread-kanban-card--locked {
+  border-color: rgba(251, 191, 36, 0.55);
+}
+
+.thread-kanban-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(251, 191, 36, 0.22);
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  color: #fef08a;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.thread-kanban-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.thread-kanban-card__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.thread-empty {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  text-align: center;
+}
+
+.thread-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(2, 6, 23, 0.65);
+  backdrop-filter: blur(14px);
+  padding: 1.5rem;
+  z-index: 10;
+}
+
+.thread-modal__card {
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: var(--shadow-soft);
+}
+
+.thread-modal__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.thread-card-divider {
+  height: 1px;
+  width: 100%;
+  background: rgba(148, 163, 184, 0.18);
+  margin: 0.5rem 0;
+}
+
+.thread-muted {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    padding: var(--spacing-lg) 1rem 3rem;
+  }
+
+  .thread-navbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .thread-nav-links {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 600px) {
+  .thread-nav-link {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .thread-panel {
+    padding: 1.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,6 @@
 /**
  * @file web/app/layout.tsx
- * @description Next.js App Router의 루트 레이아웃으로, 전역 네비게이션과 공통 스타일을 정의한다.
+ * @description Next.js App Router의 루트 레이아웃으로, 스레드 감성의 전역 네비게이션과 공통 배경을 제공한다.
  */
 
 import './globals.css';
@@ -9,31 +9,84 @@ import Link from 'next/link';
 import React from 'react';
 import { AuthProvider } from './providers';
 
+interface NavigationLink {
+  /** 네비게이션에 렌더링할 경로 */
+  href: string;
+  /** 사용자에게 노출할 라벨 */
+  label: string;
+  /** 강조가 필요한 링크인지 여부 */
+  isPrimary?: boolean;
+}
+
+/**
+ * 서비스 메타 정보를 하나의 상수로 묶어 관리해 매직 문자열을 방지한다.
+ */
+const APP_META = {
+  creatorName: 'SK.HAN',
+  publishVersion: 'v1.3.0',
+  lastUpdated: '2024-05-01'
+} as const;
+
+// 상단 네비게이션 구성을 정의해 링크 관리가 쉽도록 한다.
+const NAVIGATION_LINKS: NavigationLink[] = [
+  { href: '/login', label: '로그인' },
+  { href: '/attendance', label: '근태' },
+  { href: '/me', label: '내 업무' },
+  { href: '/dashboard', label: '대시보드', isPrimary: true }
+];
+
 export const metadata: Metadata = {
   title: 'Team Todo Console', // 브라우저 탭 제목을 정의한다.
   description: 'PocketBase 연동형 팀 할 일 & 근태 관리 도구' // 검색 엔진 설명을 제공한다.
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  // HTML 기본 구조를 정의하고 내비게이션을 렌더링한다.
+  // 전역 배경과 인증 컨텍스트를 구성해 모든 페이지가 동일한 UI를 공유하도록 한다.
   return (
     <html lang="ko">
-      <body className="min-h-screen bg-slate-50 text-slate-900">
+      <body className="app-background">
         <AuthProvider>
-          <header className="border-b bg-white">
-            <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-              <Link href="/" className="font-semibold">
-                Team Todo Console
-              </Link>
-              <div className="flex gap-4 text-sm">
-                <Link href="/login">로그인</Link>
-                <Link href="/attendance">근태</Link>
-                <Link href="/me">내 업무</Link>
-                <Link href="/dashboard">대시보드</Link>
-              </div>
-            </nav>
-          </header>
-          <main className="mx-auto max-w-5xl px-4 py-8">{children}</main>
+          <div className="app-shell">
+            <div className="app-container">
+              {/* 브랜드와 네비게이션을 스레드 스타일 카드 안에 배치한다. */}
+              <header className="thread-navbar">
+                <Link href="/" className="thread-navbar__brand">
+                  <span className="thread-navbar__brand-mark">TT</span>
+                  <span>Team Todo Console</span>
+                </Link>
+                <nav className="thread-nav-links" aria-label="주요 탐색">
+                  {NAVIGATION_LINKS.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className={`thread-nav-link${link.isPrimary ? ' thread-nav-link--primary' : ''}`}
+                    >
+                      {link.label}
+                    </Link>
+                  ))}
+                </nav>
+                {/* 서비스의 제작자와 배포 버전 정보를 우측 상단에 배치한다. */}
+                <div className="thread-navbar__meta" aria-label="서비스 메타 정보">
+                  <span className="thread-pill thread-pill--accent">Beta</span>
+                  <div className="thread-navbar__meta-item">
+                    <span className="thread-navbar__meta-label">Creator</span>
+                    <span className="thread-navbar__meta-value">{APP_META.creatorName}</span>
+                  </div>
+                  <div className="thread-navbar__meta-item">
+                    <span className="thread-navbar__meta-label">Publish</span>
+                    <span className="thread-navbar__meta-value">{APP_META.publishVersion}</span>
+                  </div>
+                  <div className="thread-navbar__meta-item">
+                    <span className="thread-navbar__meta-label">Updated</span>
+                    <span className="thread-navbar__meta-value">{APP_META.lastUpdated}</span>
+                  </div>
+                </div>
+              </header>
+
+              {/* 메인 콘텐츠를 카드 스택 형태로 렌더링한다. */}
+              <main className="thread-main">{children}</main>
+            </div>
+          </div>
         </AuthProvider>
       </body>
     </html>

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -2,7 +2,7 @@
 // Where to edit: 로그인 폼 필드나 검증 로직을 바꾸고 싶다면 아래 컴포넌트를 수정하세요.
 /**
  * @file web/app/login/page.tsx
- * @description PocketBase 이메일/비밀번호 인증을 처리하는 페이지입니다.
+ * @description PocketBase 이메일/비밀번호 인증을 최신 스레드형 카드 레이아웃으로 제공하는 페이지이다.
  */
 
 import React from 'react';
@@ -42,63 +42,60 @@ export default function LoginPage() {
   };
 
   return (
-    <section className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-bold">로그인</h1>
-        <p className="text-sm text-slate-600">PocketBase 사용자 계정을 이용해 인증합니다.</p>
-        <p className="text-xs text-slate-500">
-          현재 상태: {isAuthenticated ? `${user?.email} (${role})` : '로그아웃됨'}
-        </p>
+    <section className="thread-section">
+      <header className="thread-section__header">
+        <span className="thread-eyebrow">Authentication Thread</span>
+        <h1 className="thread-title">로그인</h1>
+        <p className="thread-subtitle">PocketBase 사용자 계정을 이용해 인증합니다. 역할에 따라 메뉴와 권한이 달라집니다.</p>
+        <p className="thread-muted">현재 상태: {isAuthenticated ? `${user?.email ?? ''} (${role})` : '로그아웃됨'}</p>
       </header>
 
-      <form className="space-y-4 rounded-lg border bg-white p-6 shadow" onSubmit={handleSubmit}>
-        <div className="space-y-1">
-          <label className="text-sm font-semibold" htmlFor="email">
-            이메일
-          </label>
-          <input
-            id="email"
-            type="email"
-            className="w-full rounded border px-3 py-2"
-            placeholder="user@company.com"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            required
-          />
-        </div>
+      <article className="thread-panel thread-panel--muted">
+        <form className="thread-form" onSubmit={handleSubmit}>
+          <div className="thread-field">
+            <label className="thread-label" htmlFor="email">
+              이메일
+            </label>
+            <input
+              id="email"
+              type="email"
+              className="thread-input"
+              placeholder="user@company.com"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </div>
 
-        <div className="space-y-1">
-          <label className="text-sm font-semibold" htmlFor="password">
-            비밀번호
-          </label>
-          <input
-            id="password"
-            type="password"
-            className="w-full rounded border px-3 py-2"
-            placeholder="비밀번호"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            required
-          />
-        </div>
+          <div className="thread-field">
+            <label className="thread-label" htmlFor="password">
+              비밀번호
+            </label>
+            <input
+              id="password"
+              type="password"
+              className="thread-input"
+              placeholder="비밀번호"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </div>
 
-        <button
-          type="submit"
-          className="w-full rounded bg-indigo-600 py-2 text-white disabled:opacity-50"
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? '로그인 중...' : '로그인'}
-        </button>
-      </form>
+          <button type="submit" className="thread-button thread-button--primary" disabled={isSubmitting}>
+            {isSubmitting ? '로그인 중...' : '로그인'}
+          </button>
+        </form>
 
-      {isAuthenticated ? (
-        <button className="rounded border px-4 py-2 text-sm" onClick={handleLogout}>
-          로그아웃
-        </button>
-      ) : null}
+        {isAuthenticated ? (
+          <button className="thread-button thread-button--ghost" onClick={handleLogout}>
+            로그아웃
+          </button>
+        ) : null}
+      </article>
 
-      {message ? <p className="text-sm text-green-600">{message}</p> : null}
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {message ? <div className="thread-alert thread-alert--success">{message}</div> : null}
+      {error ? <div className="thread-alert thread-alert--error">{error}</div> : null}
     </section>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,23 +1,132 @@
 /**
  * @file web/app/page.tsx
- * @description 홈 대시 안내 페이지로, 주요 경로와 사용 순서를 소개한다.
+ * @description 홈 대시 안내 페이지로, 주요 경로와 사용 순서를 최신 스레드 피드 스타일로 소개한다.
  */
+
+import Link from 'next/link';
+
+interface OnboardingStep {
+  /** 단계 표시용 번호 */
+  step: string;
+  /** 단계 제목 */
+  title: string;
+  /** 단계 설명 */
+  description: string;
+  /** 추가 힌트나 팁 */
+  hint: string;
+}
+
+interface QuickLink {
+  /** 이동 경로 */
+  href: string;
+  /** 링크 라벨 */
+  label: string;
+  /** 간단한 설명 */
+  description: string;
+}
+
+// 온보딩 단계 정보를 배열로 관리해 유지보수를 쉽게 한다.
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    step: '01',
+    title: 'PocketBase 계정 준비',
+    description: 'PocketBase 관리자에서 사용자 계정을 생성해 인증 흐름을 점검하세요.',
+    hint: 'Admin UI → Users → 새로운 멤버 등록'
+  },
+  {
+    step: '02',
+    title: '역할 기반 로그인 확인',
+    description: '로그인 후 상단에 표시되는 역할을 확인해 RBAC이 정상적으로 작동하는지 검증합니다.',
+    hint: '각 역할마다 다른 페이지 구성이 나타납니다.'
+  },
+  {
+    step: '03',
+    title: '근태 기록 테스트',
+    description: '출근/퇴근 버튼 상태가 현재 기록에 따라 바뀌는지 확인해 보세요.',
+    hint: '퇴근 시 확인 모달이 노출되어야 합니다.'
+  },
+  {
+    step: '04',
+    title: '개인 칸반 이동',
+    description: '작업을 드래그 대신 버튼으로 이동시켜 편집 잠금 배지를 경험해 보세요.',
+    hint: '다음 날 09:00 이후에는 관리자만 수정 가능합니다.'
+  },
+  {
+    step: '05',
+    title: '대시보드 요약 확인',
+    description: '역할에 따라 달라지는 통계 타일과 공유 제어 옵션을 살펴봅니다.',
+    hint: '관리자만 주간 보고서 공유 토글을 조정할 수 있습니다.'
+  }
+];
+
+// 빠르게 이동할 수 있는 주요 링크를 정의한다.
+const QUICK_LINKS: QuickLink[] = [
+  {
+    href: '/attendance',
+    label: '근태 기록 바로가기',
+    description: '출근/퇴근 기록과 확인 모달 UX를 체험하세요.'
+  },
+  {
+    href: '/me',
+    label: '내 업무 칸반',
+    description: '편집 잠금 뱃지와 단계 이동 버튼을 확인하세요.'
+  },
+  {
+    href: '/dashboard',
+    label: '대시보드 요약',
+    description: '역할별 통계 카드와 공유 토글을 점검하세요.'
+  }
+];
 
 export default function HomePage() {
   // 초보자에게 전체 흐름을 요약해 보여준다.
   return (
-    <section className="space-y-4">
-      <h1 className="text-2xl font-bold">팀 Todo 시스템 시작하기</h1>
-      <p>왼쪽 메뉴를 따라 로그인 → 근태 → 내 업무 → 대시보드 순으로 기능을 체험하세요.</p>
-      <ol className="list-decimal space-y-2 pl-6 text-sm">
-        <li>PocketBase 관리자에서 사용자 계정을 생성합니다.</li>
-        <li>
-          로그인 페이지에서 이메일/비밀번호로 인증 후, 상단에 표시된 역할에 따라 UI가 달라지는지 확인합니다.
-        </li>
-        <li>근태 페이지에서 출근/퇴근 버튼 상태가 현재 기록에 따라 토글되는 것을 확인합니다.</li>
-        <li>내 업무 페이지에서 칸반 컬럼 이동 시 편집 잠금 배지를 확인합니다.</li>
-        <li>대시보드 페이지에서는 역할별 주요 타일과 공유 제어 옵션을 살펴봅니다.</li>
-      </ol>
+    <section className="thread-section">
+      {/* 온보딩 소개 헤더를 렌더링한다. */}
+      <header className="thread-section__header">
+        <span className="thread-eyebrow">Onboarding Feed</span>
+        <h1 className="thread-title">팀 Todo 시스템 시작하기</h1>
+        <p className="thread-subtitle">왼쪽 메뉴를 따라 로그인 → 근태 → 내 업무 → 대시보드 순으로 기능을 체험해 보세요.</p>
+      </header>
+
+      <div className="thread-grid thread-grid--two">
+        {/* 단계별 안내를 스레드 타임라인으로 표현한다. */}
+        <article className="thread-panel thread-panel--accent">
+          <h2>온보딩 체크리스트</h2>
+          <p className="thread-panel__description">각 단계를 순서대로 확인하면 서비스 흐름이 빠르게 이해됩니다.</p>
+          <ul className="thread-timeline">
+            {ONBOARDING_STEPS.map((step) => (
+              <li key={step.step} className="thread-timeline__item">
+                <span className="thread-timeline__badge">{step.step}</span>
+                <div className="thread-timeline__body">
+                  <p className="thread-timeline__title">{step.title}</p>
+                  <p>{step.description}</p>
+                  <p className="thread-timeline__hint">{step.hint}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        {/* 빠른 액션 패널을 렌더링한다. */}
+        <aside className="thread-panel thread-panel--muted">
+          <h2>바로가기</h2>
+          <p className="thread-panel__description">주요 페이지를 즉시 열어 스레드형 UX를 체험하세요.</p>
+          <div className="thread-card-divider" />
+          {QUICK_LINKS.map((link, index) => {
+            const isLastLink = index === QUICK_LINKS.length - 1; // 마지막 항목 여부를 계산한다.
+            return (
+              <div key={link.href}>
+                <Link href={link.href} className="thread-button thread-button--link">
+                  <span>{link.label}</span>
+                </Link>
+                <p className="thread-muted">{link.description}</p>
+                {!isLastLink ? <div className="thread-card-divider" /> : null}
+              </div>
+            );
+          })}
+        </aside>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- replace the global styles with a thread-inspired glassmorphism theme and reusable utility classes
- rework the root layout navigation into a branded thread navbar with beta badge and primary link state
- restyle the home, login, attendance, me, and dashboard pages with card/timeline layouts, buttons, alerts, and modals that match the new visual language
- surface creator attribution and publish version badges within the navbar meta area to satisfy the new UX request

## Testing
- npm --prefix web run lint

## Screenshots
- ![Navbar metadata](browser:/invocations/ptmtdrfm/artifacts/artifacts/navbar-meta.png)


------
https://chatgpt.com/codex/tasks/task_e_68cff93e25b88330bae344ef4ef55b4a